### PR TITLE
feat: add conventional commit lint checks with husky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+
+# dependencies
+/node_modules
+
+# misc
+yarn-error.log
+/.env.local
+package-lock.json
+# System Files
+.DS_Store
+
+*.env

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit ${1}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "@commitlint/cli": "^17.4.4",
+    "@commitlint/config-conventional": "^17.4.4",
+    "husky": "^8.0.3"
+  }
+}


### PR DESCRIPTION
This PR is to add conventional commit lint and cli with husky to the repository, so that each commit is checked with respect to the conventional commit spec 

Here is a summary of the conventional commit spec: https://www.conventionalcommits.org/en/v1.0.0/#summary

Dev Dependencies added: 

- [CommitLint: conventional commit and the cli](https://github.com/conventional-changelog/commitlint)
- [Husky git hooks](https://www.npmjs.com/package/husky?activeTab=readme)

Set-up guide followed: https://commitlint.js.org/#/guides-local-setup